### PR TITLE
Fix for compatibility with sidekiq >= 6.1.0

### DIFF
--- a/lib/sidekiq-rate-limiter/server.rb
+++ b/lib/sidekiq-rate-limiter/server.rb
@@ -2,5 +2,10 @@ require 'sidekiq-rate-limiter/version'
 require 'sidekiq-rate-limiter/fetch'
 
 Sidekiq.configure_server do |config|
-  Sidekiq.options[:fetch] = Sidekiq::RateLimiter::Fetch
+  # Backwards compatibility for Sidekiq < 6.1.0 (see https://github.com/mperham/sidekiq/pull/4602 for details)
+  if (Sidekiq::BasicFetch.respond_to?(:bulk_requeue))
+    Sidekiq.options[:fetch] = Sidekiq::RateLimiter::Fetch
+  else
+    Sidekiq.options[:fetch] = Sidekiq::RateLimiter::Fetch.new(Sidekiq.options)
+  end
 end

--- a/spec/sidekiq-rate-limiter/server_spec.rb
+++ b/spec/sidekiq-rate-limiter/server_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe Sidekiq::RateLimiter, 'server configuration' do
 
   it 'should set Sidekiq.options[:fetch] as desired' do
     Sidekiq.configure_server do |config|
-      expect(Sidekiq.options[:fetch]).to eql(Sidekiq::RateLimiter::Fetch)
+      expect(Sidekiq.options[:fetch]).to be_an_instance_of(Sidekiq::RateLimiter::Fetch)
     end
   end
 
   it 'should inherit from Sidekiq::BasicFetch' do
     Sidekiq.configure_server do |config|
-      expect(Sidekiq.options[:fetch]).to be < Sidekiq::BasicFetch
+      expect(Sidekiq.options[:fetch].class).to be < Sidekiq::BasicFetch
     end
   end
 end


### PR DESCRIPTION
A refactoring in the internal Fetch API was introduced in Sidekiq 6.1.0 that is not backwards compatible.

As part of this refactoring the object in the `:fetch` option is expected to be an instance of `Sidekiq::BasicFetch` or an object that responds to the same methods instead of a `Class` as it used to be. 

This change allows using the gem with newer versions while keeping compatibility with old ones. See https://github.com/mperham/sidekiq/pull/4602 for more details.